### PR TITLE
Refactor/core implementation

### DIFF
--- a/Inflection Tests/Inflection_Tests.swift
+++ b/Inflection Tests/Inflection_Tests.swift
@@ -26,10 +26,10 @@ class Inflection_Tests: XCTestCase {
     }
     
     func testDictionaryInflection() {
-        let remoteDictionary: NSDictionary = ["created_at":"", "updated_at":""]
-        let localDictionary: NSDictionary = ["createdAt":"", "updatedAt":""]
-        
-        XCTAssertEqual(remoteDictionary.swiftCase(), localDictionary)
+        let remoteDictionary = ["created_at":"", "updated_at":""]
+        let localDictionary = ["createdAt":"", "updatedAt":""]
+
+        XCTAssertEqual((remoteDictionary as NSDictionary).swiftCase(), localDictionary as NSDictionary)
     }
     
 }

--- a/Source/Inflection.swift
+++ b/Source/Inflection.swift
@@ -10,17 +10,16 @@ import Foundation
 
 public extension NSDictionary {
     
-    func swiftCase() -> NSDictionary {
+    func swiftCase() -> Dictionary<String, Any?> {
         return self.inflectDictionaryKeys({ (string) -> String in string.swiftCase()})
     }
     
-    func rubyCase() -> NSDictionary {
-        return self.inflectDictionaryKeys({ (string) -> String in string.rubyCase()}) as NSDictionary
+    func rubyCase() -> Dictionary<String, Any?> {
+        return self.inflectDictionaryKeys({ (string) -> String in string.rubyCase()})
     }
     
-    private func inflectDictionaryKeys(closure: (string: String) -> String) -> NSDictionary {
-
-        let newDictionary = NSMutableDictionary.new()
+    private func inflectDictionaryKeys(closure: (string: String) -> String) -> Dictionary<String, Any?> {
+        var newDictionary = Dictionary<String, Any?>()
         map(self) { newDictionary[closure(string: $0 as! String)] = $1 }
 
         return newDictionary

--- a/Source/Inflection.swift
+++ b/Source/Inflection.swift
@@ -10,19 +10,19 @@ import Foundation
 
 public extension NSDictionary {
     
-    func swiftCase() -> Dictionary<String, Any?> {
+    func swiftCase() -> NSDictionary {
         return self.inflectDictionaryKeys({ (string) -> String in string.swiftCase()})
     }
     
-    func rubyCase() -> Dictionary<String, Any?> {
+    func rubyCase() -> NSDictionary {
         return self.inflectDictionaryKeys({ (string) -> String in string.rubyCase()})
     }
     
-    private func inflectDictionaryKeys(closure: (string: String) -> String) -> Dictionary<String, Any?> {
-        var newDictionary = Dictionary<String, Any?>()
+    private func inflectDictionaryKeys(closure: (string: String) -> String) -> NSDictionary {
+        var newDictionary = NSMutableDictionary.new()
         map(self) { newDictionary[closure(string: $0 as! String)] = $1 }
 
-        return newDictionary
+        return newDictionary.copy() as! NSDictionary
     }
     
 }

--- a/Source/Inflection.swift
+++ b/Source/Inflection.swift
@@ -11,104 +11,102 @@ import Foundation
 public extension NSDictionary {
     
     func swiftCase() -> NSDictionary {
-        return self.inflectDictionaryKeys({ (string) -> NSString in string.swiftCase()})
+        return self.inflectDictionaryKeys({ (string) -> String in string.swiftCase()})
     }
     
     func rubyCase() -> NSDictionary {
-        return self.inflectDictionaryKeys({ (string) -> NSString in string.rubyCase()})
+        return self.inflectDictionaryKeys({ (string) -> String in string.rubyCase()}) as NSDictionary
     }
     
-    private func inflectDictionaryKeys(closure: (string: NSString) -> NSString) -> NSDictionary {
-        let mutableDictionary = NSMutableDictionary.new()
-        
-        self.enumerateKeysAndObjectsUsingBlock { (keyString, value, stop) -> () in
-            mutableDictionary[closure(string: keyString as! NSString)] = value
-        }
-        
-        return mutableDictionary as NSDictionary
+    private func inflectDictionaryKeys(closure: (string: String) -> String) -> NSDictionary {
+
+        let newDictionary = NSMutableDictionary.new()
+        map(self) { newDictionary[closure(string: $0 as! String)] = $1 }
+
+        return newDictionary
     }
     
 }
 
-public extension NSString {
+public extension String {
     
-    func camelCase() -> NSString {
+    func camelCase() -> String {
         return self.replaceIdentifierWithString("").lowerCaseFirstLetter()
     }
     
-    func classify() -> NSString {
+    func classify() -> String {
         return self.upperCamelCase()
     }
     
-    func dashedCase() -> NSString {
+    func dashedCase() -> String {
         return self.lowerCaseFirstLetter().replaceIdentifierWithString("-")
     }
     
-    func dotNetCase() -> NSString {
+    func dotNetCase() -> String {
         return self.upperCamelCase()
     }
     
-    func javascriptCase() -> NSString {
+    func javascriptCase() -> String {
         return self.replaceIdentifierWithString("").lowerCaseFirstLetter()
     }
     
-    func lispCase() -> NSString {
+    func lispCase() -> String {
         return self.dashedCase()
     }
     
-    func objcCase() -> NSString {
+    func objcCase() -> String {
         return self.camelCase()
     }
     
-    func pythonCase() -> NSString {
+    func pythonCase() -> String {
         return self.snakeCase()
     }
     
-    func snakeCase() -> NSString {
+    func snakeCase() -> String {
         return self.underscoreCase()
     }
     
-    func swiftCase() -> NSString {
-        return self.objcCase()
+    func swiftCase() -> String {
+        return self.camelCase()
     }
     
-    func underscoreCase() -> NSString {
-        return self.lowerCaseFirstLetter().replaceIdentifierWithString("_")
+    func underscoreCase() -> String {
+        return (self.lowerCaseFirstLetter() as String).replaceIdentifierWithString("_")
     }
     
-    func upperCamelCase() -> NSString {
+    func upperCamelCase() -> String {
         return self.camelCase().upperCamelCase()
     }
     
-    func rubyCase () -> NSString {
+    func rubyCase () -> String {
         return self.snakeCase()
     }
     
-    func humanize() -> NSString {
+    func humanize() -> String {
         return self.replaceIdentifierWithString(" ").capitalizedString
     }
     
-    private func lowerCaseFirstLetter() -> NSString {
+    private func lowerCaseFirstLetter() -> String {
         var mutableString = self.mutableCopy() as! NSMutableString
         mutableString.replaceCharactersInRange(NSMakeRange(0, 1), withString: self.firstLetter().lowercaseString as String)
-        
-        return mutableString.copy() as! NSString
+
+        return mutableString.copy() as! String
     }
     
-    private func upperCaseFirstLetter() -> NSString {
+    private func upperCaseFirstLetter() -> String {
         var mutableString = self.mutableCopy() as! NSMutableString
         mutableString.replaceCharactersInRange(NSMakeRange(0, 1), withString: self.firstLetter().uppercaseString as String)
         
-        return mutableString.copy() as! NSString
+        return mutableString.copy() as! String
     }
     
-    private func firstLetter() -> NSString {
-        return self.substringToIndex(1)
+    private func firstLetter() -> String {
+        return (self as NSString).substringToIndex(1) as String
     }
     
-    private func replaceIdentifierWithString(identifier: String) -> NSString {
-        
-        let scanner = NSScanner.init(string: self as! String)
+    private func replaceIdentifierWithString(identifier: String) -> String {
+
+        let scanner = NSScanner.init(string: self)
         let identifierSet = NSCharacterSet.init(charactersInString: identifier)
         let alphaNumericSet = NSCharacterSet.alphanumericCharacterSet()
         let uppercaseSet = NSCharacterSet.uppercaseLetterCharacterSet()
@@ -140,8 +138,8 @@ public extension NSString {
             }
             
         }
-        
-        return output
+
+        return output.copy() as! String
     }
     
 }


### PR DESCRIPTION
Swift does not allow public extensions for generic types, hence forcing Inflection to live on NSDictionary.

> Extension of generic type 'Dictionary<Key, Value>' from a different
> module cannot provide public declarations
